### PR TITLE
C5141-1330: Ignore dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,14 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - node
   - package-ecosystem: 'docker-compose'
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - redis
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Ignore depenencies
- Node: We only want to use LTS version, so will handle manually
- Redis: We want to match the version used in Cloud Platform