### PR TITLE
C5141-1330: fix dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,13 +29,13 @@ updates:
     schedule:
       interval: 'daily'
     ignore:
-      - node
+      - dependency-name: node
   - package-ecosystem: 'docker-compose'
     directory: '/'
     schedule:
       interval: 'daily'
     ignore:
-      - redis
+      - dependency-name: redis
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
I think the ignore is working correctly for dependabot.  https://github.com/ministryofjustice/care-arrangement-plan/network/updates