### PR TITLE
content/DAS-556 Update external links to indicate they are external

### DIFF
--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -59,16 +59,17 @@
         <a
           href="https://www.citizensadvice.org.uk/family/making-agreements-about-your-children/making-child-arrangements"
           target="_blank" rel="noopener noreferrer" title="Visit citizens advice"
-          >Find another way to make arrangements from citizens advice</a
+          >Find another way to make arrangements from citizens advice (opens in new tab)</a
         >.
       </p>
 
       <p><a href="https://www.nspcc.org.uk/what-is-child-abuse"
         target="_blank" rel="noopener noreferrer" title="Visit NSPCC to find out about child abuse and neglect"
-        >Find out more about child abuse and neglect from the NSPCC</a>.</p>
+        >Find out more about child abuse and neglect from the NSPCC (opens in new tab)</a>.</p>
       <p>
         <a href="https://www.gov.uk/guidance/domestic-abuse-how-to-get-help#recognise-domestic-abuse"
-          >Find out more about signs of domestic violence</a
+          target="_blank" rel="noopener noreferrer" title="Find out about signs of domestic violence"
+          >Find out more about signs of domestic violence (opens in new tab)</a
         >
         if you're unsure whether you're a victim.
       </p>
@@ -76,7 +77,7 @@
       <p>
         <a href="https://www.cafcass.gov.uk/sites/default/files/migrated/Top-Tips-for-parents-who-are-separated.pdf"
           target="_blank" rel="noopener noreferrer" title="Visit cafass to see tips for parents"
-          >Tips for parents</a
+          >Visit cafass to see tips for parents (pdf opens in new tab)</a
         >
         from a child's perspective.
       </p>


### PR DESCRIPTION
### Summary of Changes
**Problem Addressed**

On the start page there are links that link to other sites (e.g. NSPCC) where the user is not informed that they will be leaving a Gov/MoJ site.

**Changes Made**
- External links now let the user know they are going to another site 
<img width="731" height="545" alt="image" src="https://github.com/user-attachments/assets/519c9132-ae26-46b6-9687-8e99565d16fa" />

