### PR TITLE
DAS-834 set trust proxy to true and trusted proxy to 1

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -25,7 +25,7 @@ const createApp = (): express.Application => {
   const app = express();
 
   app.set('json spaces', 2);
-  app.set('trust proxy', true);
+  app.set('trust proxy', 1);
   app.set('port', process.env.PORT || 3000);
   // Disable X-Powered-By header for security
   app.disable('x-powered-by');

--- a/server/middleware/setupRateLimit.ts
+++ b/server/middleware/setupRateLimit.ts
@@ -31,7 +31,7 @@ const setupRateLimit = () => {
     max: 250, // Limit each IP to 250 requests per 15 minutes
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-    validate: { trustProxy: false },
+    validate: { trustProxy: true },
     store,
     skip: (req: Request) => {
       return '/health' === req.path || req.path.startsWith('/assets');
@@ -45,7 +45,7 @@ const setupRateLimit = () => {
     max: 2000, // Limit downloads to 20 per 15 minutes per IP
     standardHeaders: true,
     legacyHeaders: false,
-    validate: { trustProxy: false },
+    validate: { trustProxy: true },
     store,
     handler: rateLimitHandler,
     skipSuccessfulRequests: false, // Count all requests, even successful ones
@@ -57,7 +57,7 @@ const setupRateLimit = () => {
     max: 10, // Limit login attempts to 10 per 15 minutes per IP
     standardHeaders: true,
     legacyHeaders: false,
-    validate: { trustProxy: false },
+    validate: { trustProxy: true},
     store,
     handler: rateLimitHandler,
     skipSuccessfulRequests: true, // Only count failed requests


### PR DESCRIPTION
Because the app runs behind a proxy, trust proxy must be enabled for correct IP detection.


The following ensures only the first proxy is trusted
app.set('trust proxy', 1);
