### PR TITLE
DAS-819 Add password screen and remove auth layer

### DIFF
--- a/deploy/development/ingress.tpl.yml
+++ b/deploy/development/ingress.tpl.yml
@@ -6,9 +6,6 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: ${KUBE_NAMESPACE}-ingress-${KUBE_NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: '100'
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: basic-auth-secret
-    nginx.ingress.kubernetes.io/auth-realm: 'Development User | Authentication Required'
     nginx.ingress.kubernetes.io/enable-modsecurity: 'true'
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecAuditEngine On

--- a/deploy/staging/ingress.tpl.yml
+++ b/deploy/staging/ingress.tpl.yml
@@ -6,9 +6,6 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: ${KUBE_NAMESPACE}-ingress-${KUBE_NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: '100'
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: basic-auth-secret
-    nginx.ingress.kubernetes.io/auth-realm: 'Staging User | Authentication Required'
     nginx.ingress.kubernetes.io/enable-modsecurity: 'true'
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecAuditEngine On

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,6 +6,7 @@ import logger from './logging/logger';
 import setupPageVisitAnalytics from './logging/setupPageVisitAnalytics';
 import setupRequestLogging from './logging/setupRequestLogging';
 import setupAnalytics from './middleware/setupAnalytics';
+import setupAuthentication from './middleware/setupAuthentication';
 import setUpCsrf from './middleware/setUpCsrf';
 import setUpHealthCheck from './middleware/setUpHealthCheck';
 import setupHistory from './middleware/setupHistory';
@@ -18,7 +19,7 @@ import setUpStaticResources from './middleware/setUpStaticResources';
 import setUpWebSecurity from './middleware/setUpWebSecurity';
 import setUpWebSession from './middleware/setUpWebSession';
 import routes from './routes';
-// import unauthenticatedRoutes from './routes/unauthenticatedRoutes';
+import unauthenticatedRoutes from './routes/unauthenticatedRoutes';
 import nunjucksSetup from './utils/nunjucksSetup';
 
 const createApp = (): express.Application => {
@@ -45,8 +46,8 @@ const createApp = (): express.Application => {
   app.use(setupAnalytics());
   app.use(setupHistory());
   // app.use(setupServiceNoLongerAvailable());
-  // app.use(unauthenticatedRoutes());
-  // app.use(setupAuthentication());
+  app.use(unauthenticatedRoutes());
+  app.use(setupAuthentication());
   app.use(routes());
 
   app.use((_request, _response, next) => next(createError(404)));


### PR DESCRIPTION
**Context**
Some computers block the password popup and they only see the 'nginx unauthorised' error. 

**Development Changes**

In this PR I have brought back the password screen to replace the password popup introduced by the authentication layer in ingress. 


