### PR TITLE
Add workflow for manual branch deployment

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,0 +1,38 @@
+name: Deploy Branch to Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - development
+          - staging
+
+concurrency:
+  group: deploy-${{ github.event.inputs.environment }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: 'Validate'
+    uses: ./.github/workflows/validation.yml
+    secrets: inherit
+
+  image:
+    name: 'Build & Push Image'
+    uses: ./.github/workflows/build-push-image.yml
+    needs: [validate]
+    secrets: inherit
+
+  deploy:
+    name: 'Deploy to ${{ github.event.inputs.environment }}'
+    uses: ./.github/workflows/deploy.yml
+    needs: [image, validate]
+    with:
+      environment: ${{ github.event.inputs.environment }}
+      registry: ${{ needs.image.outputs.registry }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that allows manual deployment of any branch to staging or development environments
- Useful for testing PoC branches without merging to main

## How to use
1. Go to Actions tab
2. Select "Deploy Branch to Environment"
3. Click "Run workflow"
4. Select your branch and target environment (staging/development)

## Test plan
- [ ] Workflow appears in Actions tab after merge
- [ ] Can successfully deploy a branch to development
- [ ] Can successfully deploy a branch to staging